### PR TITLE
Add `mock` option to `GRPC.Channel`

### DIFF
--- a/lib/conn_grpc/channel.ex
+++ b/lib/conn_grpc/channel.ex
@@ -201,8 +201,8 @@ defmodule ConnGRPC.Channel do
   end
 
   @impl true
-  def handle_call(:get, _from, %{mock: mock} = state) when mock != nil do
-    {:reply, mock.(), state}
+  def handle_call(:get, {caller, _}, %{mock: mock} = state) when mock != nil do
+    {:reply, mock.(caller), state}
   end
 
   def handle_call(:get, _from, state) do

--- a/lib/conn_grpc/channel.ex
+++ b/lib/conn_grpc/channel.ex
@@ -108,6 +108,9 @@ defmodule ConnGRPC.Channel do
     * `:on_disconnect` - Function to run on disconnect (0-arity)
 
     * `:grpc_stub` - GRPC stub module that will receive the `connect/2` call (default: `GRPC.Stub`)
+
+    * `:mock` - A function that if provided, will override calls to `get/1`.
+    It can be useful for mocking channel connection in parallel tests.
   """
   def start_link(options) when is_list(options) do
     GenServer.start_link(__MODULE__, options, name: options[:name])
@@ -146,6 +149,7 @@ defmodule ConnGRPC.Channel do
         opts: Keyword.get(options, :opts, [])
       },
       debug: Keyword.get(options, :debug, false),
+      mock: Keyword.get(options, :mock),
       name: Keyword.get(options, :name),
       pool_name: Keyword.get(options, :pool_name),
       on_connect: Keyword.get(options, :on_connect, fn -> nil end),
@@ -197,6 +201,10 @@ defmodule ConnGRPC.Channel do
   end
 
   @impl true
+  def handle_call(:get, _from, %{mock: mock} = state) when mock != nil do
+    {:reply, mock.(), state}
+  end
+
   def handle_call(:get, _from, state) do
     response =
       case state.channel do

--- a/test/conn_grpc/channel_test.exs
+++ b/test/conn_grpc/channel_test.exs
@@ -363,11 +363,16 @@ defmodule ConnGRPC.ChannelTest do
     end
 
     test "uses mock when provided" do
+      parent = self()
+
       {:ok, channel_pid} =
         Channel.start_link(
           address: "address",
           opts: [adapter: GRPC.Client.TestAdapters.Success],
-          mock: fn -> {:ok, %GRPC.Channel{adapter: :mock}} end
+          mock: fn caller ->
+            assert caller == parent
+            {:ok, %GRPC.Channel{adapter: :mock}}
+          end
         )
 
       assert {:ok, %GRPC.Channel{adapter: :mock}} = Channel.get(channel_pid)

--- a/test/conn_grpc/channel_test.exs
+++ b/test/conn_grpc/channel_test.exs
@@ -361,6 +361,17 @@ defmodule ConnGRPC.ChannelTest do
         _metadata = %{channel: :test_channel}
       }
     end
+
+    test "uses mock when provided" do
+      {:ok, channel_pid} =
+        Channel.start_link(
+          address: "address",
+          opts: [adapter: GRPC.Client.TestAdapters.Success],
+          mock: fn -> {:ok, %GRPC.Channel{adapter: :mock}} end
+        )
+
+      assert {:ok, %GRPC.Channel{adapter: :mock}} = Channel.get(channel_pid)
+    end
   end
 
   describe "__using__" do


### PR DESCRIPTION
Adds a `mock` option for mocking GRPC connection in parallel tests.

This function allows the upcoming `MockGRPC` lib to hook into `ConnGRPC` so that we can test what happens when it fails to get a connection from the pool in async tests.