### PR TITLE
Add support for `:otp_app` option in ConnGRPC.Pool for configuration loading

### DIFF
--- a/lib/conn_grpc/pool.ex
+++ b/lib/conn_grpc/pool.ex
@@ -21,6 +21,26 @@ defmodule ConnGRPC.Pool do
           channel: [address: "localhost:50051", opts: []]
       end
 
+  You can also use the `:otp_app` option to load configuration from your application's config:
+
+      defmodule DemoPool do
+        use ConnGRPC.Pool, otp_app: :my_app
+      end
+
+  This will load configuration from `Application.get_env(:my_app, DemoPool, [])` and merge it
+  with the options passed to `child_spec/1`.
+
+  Then configure it in your `config/runtime.exs`:
+
+      import Config
+
+      config :my_app, DemoPool,
+        pool_size: String.to_integer(System.get_env("GRPC_POOL_SIZE", "5")),
+        channel: [
+          address: System.fetch_env!("GRPC_ADDRESS"),
+          opts: []
+        ]
+
   The format of `address` and `opts` is the same used by
   [`GRPC.Stub.connect/2`](https://hexdocs.pm/grpc/0.5.0/GRPC.Stub.html#connect/2)
 
@@ -99,8 +119,17 @@ defmodule ConnGRPC.Pool do
       def get_all_pids, do: ConnGRPC.Pool.get_all_pids(__MODULE__)
 
       def child_spec(opts) do
+        {otp_app, use_opts} = Keyword.pop(unquote(use_opts), :otp_app)
+
+        app_env_opts =
+          case otp_app do
+            nil -> []
+            app -> Application.get_env(app, __MODULE__, [])
+          end
+
         [name: __MODULE__]
-        |> Keyword.merge(unquote(use_opts))
+        |> Keyword.merge(use_opts)
+        |> Keyword.merge(app_env_opts)
         |> Keyword.merge(opts)
         |> ConnGRPC.Pool.child_spec()
         |> Supervisor.child_spec(id: __MODULE__)

--- a/test/conn_grpc/pool_test.exs
+++ b/test/conn_grpc/pool_test.exs
@@ -334,6 +334,44 @@ defmodule ConnGRPC.PoolTest do
       assert {:ok, %GRPC.Channel{}} = UsingTestPool.get_channel()
       assert is_list(UsingTestPool.get_all_pids())
     end
+
+    test "loads configuration from Application.get_env when otp_app is specified" do
+      defmodule UsingTestPoolWithConfig do
+        use ConnGRPC.Pool, otp_app: :test_app
+      end
+
+      Application.put_env(:test_app, UsingTestPoolWithConfig,
+        pool_size: 2,
+        channel: [address: "test_address", opts: [adapter: GRPC.Client.TestAdapters.Success]]
+      )
+
+      child_spec = UsingTestPoolWithConfig.child_spec([])
+      {_module, _function, [opts]} = child_spec.start
+
+      assert opts[:pool_size] == 2
+      assert opts[:channel][:address] == "test_address"
+      assert opts[:name] == UsingTestPoolWithConfig
+
+      Application.delete_env(:test_app, UsingTestPoolWithConfig)
+    end
+
+    test "merges Application.get_env config with child_spec opts" do
+      defmodule UsingTestPoolWithMerge do
+        use ConnGRPC.Pool, otp_app: :test_app
+      end
+
+      Application.put_env(:test_app, UsingTestPoolWithMerge,
+        pool_size: 2,
+        channel: [address: "test_address", opts: [adapter: GRPC.Client.TestAdapters.Success]]
+      )
+
+      child_spec = UsingTestPoolWithMerge.child_spec(pool_size: 3)
+      {_module, _function, [opts]} = child_spec.start
+
+      assert Keyword.get(opts, :pool_size) == 3
+
+      Application.delete_env(:test_app, UsingTestPoolWithMerge)
+    end
   end
 
   defp send_disconnect_msg(pid), do: send(pid, {:gun_down, fake_pid(), :http2, :normal, []})


### PR DESCRIPTION
Hey team, thank you so much for package, we are trying to adopt and we found that we needed to call `Application.get_env/2` in the application.

This PR adds support for loading pool configuration from `Application.get_env/3` when using the module-based pool pattern. Added the `:otp_app` option to the `__using__` macro, allowing pools to load their configuration from application environment:

```elixir
defmodule MyApp.MyPool do
  use ConnGRPC.Pool, otp_app: :my_app
end
```

Configuration can then be set in `runtime.exs`:

```elixir
config :my_app, MyApp.MyPool,
  pool_size: 5,
  channel: [address: System.get_env("MY_APP_MY_POOL_ADDRESS"]
```

Useful to configure things from `runtime.ex` without the developers having to come up with that many ways to configure the pools